### PR TITLE
Windowsで終了ボタンが反応しない問題を修正

### DIFF
--- a/src/config/window.json
+++ b/src/config/window.json
@@ -3,5 +3,6 @@
 	"height"      : 150,
 	"transparent" : true,
 	"frame"       : false,
-	"resizable"   : false
+	"resizable"   : false,
+	"maximizable" : false
 }

--- a/src/scripts/components/tag/title-bar.tag
+++ b/src/scripts/components/tag/title-bar.tag
@@ -16,6 +16,7 @@ title-bar
 			width: 12px;
 			height: 12px;
 			border-radius: 50%;
+			cursor: pointer;
 			-webkit-app-region: no-drag;
 		}
 		:scope .close:before,

--- a/src/scripts/components/tag/title-bar.tag
+++ b/src/scripts/components/tag/title-bar.tag
@@ -16,6 +16,7 @@ title-bar
 			width: 12px;
 			height: 12px;
 			border-radius: 50%;
+			-webkit-app-region: no-drag;
 		}
 		:scope .close:before,
 		:scope .close:after {


### PR DESCRIPTION
- 終了ボタンのクリックイベントが発火しない問題を修正
- タイトルバーをダブルクリックしたときにウィンドウが最大化になるのを防止
- 終了ボタンのカーソルをポインターに変更